### PR TITLE
Fix wait for tailscale

### DIFF
--- a/bin/heroku-tailscale-start.sh
+++ b/bin/heroku-tailscale-start.sh
@@ -10,15 +10,20 @@ fi
 wait_for_tailscale_running() {
   timeout=5     # Timeout in seconds
   interval=0.5  # Interval between checks
+
+  # convert to milliseconds so we can use integer math
+  timeout_ms=$(awk "BEGIN {print $timeout * 1000}")
+  interval_ms=$(awk "BEGIN {print $interval * 1000}")
+
   elapsed=0
 
-  while [ "$elapsed" -lt "$timeout" ]; do
+  while [ "$elapsed" -lt "$timeout_ms" ]; do
     state=$(tailscale status -json | jq -r .BackendState)
     if [ "$state" = "Running" ]; then
       return 0
     fi
     sleep "$interval"
-    elapsed=$(echo "$elapsed + $interval" | bc)
+    elapsed=$((elapsed + interval_ms))
   done
 
   return 1

--- a/bin/heroku-tailscale-start.sh
+++ b/bin/heroku-tailscale-start.sh
@@ -8,20 +8,20 @@ if [ -z "$TAILSCALE_AUTH_KEY" ]; then
 fi
 
 wait_for_tailscale_running() {
-    timeout=5     # Timeout in seconds
-    interval=0.5  # Interval between checks
-    elapsed=0
+  timeout=5     # Timeout in seconds
+  interval=0.5  # Interval between checks
+  elapsed=0
 
-    while [ "$elapsed" -lt "$timeout" ]; do
-        state=$(tailscale status -json | jq -r .BackendState)
-        if [ "$state" = "Running" ]; then            
-            return 0
-        fi
-        sleep "$interval"
-        elapsed=$(echo "$elapsed + $interval" | bc)
-    done
-    
-    return 1
+  while [ "$elapsed" -lt "$timeout" ]; do
+    state=$(tailscale status -json | jq -r .BackendState)
+    if [ "$state" = "Running" ]; then
+      return 0
+    fi
+    sleep "$interval"
+    elapsed=$(echo "$elapsed + $interval" | bc)
+  done
+
+  return 1
 }
 
 if [ -z "$TAILSCALE_HOSTNAME" ]; then
@@ -39,7 +39,7 @@ else
   TAILSCALE_HOSTNAME="$TAILSCALE_HOSTNAME"
 fi
 tailscaled -cleanup > /dev/null 2>&1
-(tailscaled -verbose ${TAILSCALED_VERBOSE:--1} --tun=userspace-networking --socks5-server=localhost:1055 > /dev/null 2>&1 &)  
+(tailscaled -verbose ${TAILSCALED_VERBOSE:--1} --tun=userspace-networking --socks5-server=localhost:1055 > /dev/null 2>&1 &)
 tailscale up \
   --authkey="${TAILSCALE_AUTH_KEY}?preauthorized=true&ephemeral=true" \
   --hostname="$TAILSCALE_HOSTNAME" \

--- a/bin/heroku-tailscale-start.sh
+++ b/bin/heroku-tailscale-start.sh
@@ -8,7 +8,7 @@ if [ -z "$TAILSCALE_AUTH_KEY" ]; then
 fi
 
 wait_for_tailscale_running() {
-  timeout=5     # Timeout in seconds
+  timeout=${TAILSCALE_RUNNING_TIMEOUT:-5} # Timeout in seconds
   interval=0.5  # Interval between checks
 
   # convert to milliseconds so we can use integer math


### PR DESCRIPTION
Heroku's 24 stack does not include `bc`, so waiting for tailscale to be up does not work. This PR changes the function to use awk for the calculation.

In addition I've added the ability to configure the timeout by setting `TAILSCALE_RUNNING_TIMEOUT` in the environment.